### PR TITLE
Zendesk tickets side load objects

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include LICENSE
 include tap_zendesk/schemas/*.json
 include tap_zendesk/schemas/shared/*.json
+include tap_zendesk/schemas/sideload_schemas/*.json

--- a/Makefile
+++ b/Makefile
@@ -4,3 +4,9 @@
 test:
 	pylint tap_zendesk -d missing-docstring,invalid-name,line-too-long,too-many-locals,too-few-public-methods,fixme,stop-iteration-return,too-many-branches,useless-import-alias,no-else-return,logging-not-lazy
 	nosetests test/unittests
+
+
+setup-environment:
+	rm -rf env || true
+	python3 -m venv env/tap-zendesk
+	source env/tap-zendesk/bin/activate && pip3 install .

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,10 @@
 
 from setuptools import setup
 
-setup(name='twilio-tap-zendesk',
-      version='1.0.1',
+setup(
+    # name='twilio-tap-zendesk',
+      name='twiliointernal_tap-zendesk-des-1610',
+      version='0.0.1',
       description='Singer.io tap for extracting data from the Zendesk API',
       author='Twilio',
       url='https://github.com/twilio-labs/twilio-tap-zendesk',

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,8 @@
 from setuptools import setup
 
 setup(
-      name='twilio-tap-zendesk-guptaa3',
-      version='0.0.1',
+      name='twilio-tap-zendesk',
+      version='1.0.2',
       description='Singer.io tap for extracting data from the Zendesk API',
       author='Twilio',
       url='https://github.com/twilio-labs/twilio-tap-zendesk',

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,7 @@
 from setuptools import setup
 
 setup(
-    # name='twilio-tap-zendesk',
-      name='twiliointernal_tap-zendesk-des-1610',
+      name='twilio-tap-zendesk-guptaa3',
       version='0.0.1',
       description='Singer.io tap for extracting data from the Zendesk API',
       author='Twilio',

--- a/tap_zendesk/__init__.py
+++ b/tap_zendesk/__init__.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
 import json
-import sys
+import sys, os
 
 from zenpy import Zenpy
 import requests
 from requests import Session
 from requests.adapters import HTTPAdapter
 import singer
-from singer import metadata, metrics as singer_metrics
+from singer import metadata, Schema, metrics as singer_metrics
 from tap_zendesk import metrics as zendesk_metrics
 from tap_zendesk.discover import discover_streams
 from tap_zendesk.streams import STREAMS
@@ -34,11 +34,15 @@ API_TOKEN_CONFIG_KEYS = [
 # patch Session.request to record HTTP request metrics
 request = Session.request
 
+
 def request_metrics_patch(self, method, url, **kwargs):
     with singer_metrics.http_request_timer(None):
         return request(self, method, url, **kwargs)
 
+
 Session.request = request_metrics_patch
+
+
 # end patch
 
 def do_discover(client):
@@ -47,8 +51,10 @@ def do_discover(client):
     json.dump(catalog, sys.stdout, indent=2)
     LOGGER.info("Finished discover")
 
+
 def stream_is_selected(mdata):
     return mdata.get((), {}).get('selected', False)
+
 
 def get_selected_streams(catalog):
     selected_stream_names = []
@@ -63,14 +69,37 @@ SUB_STREAMS = {
     'tickets': ['ticket_audits', 'ticket_metrics', 'ticket_comments']
 }
 
+# only side loading objects that are returned as a child object and not a separate array
+SIDELOAD_OBJECTS = {
+    'tickets': ['metric_sets', 'dates', 'comment_count', 'slas']
+}
+
+
 def get_sub_stream_names():
     sub_stream_names = []
     for parent_stream in SUB_STREAMS:
         sub_stream_names.extend(SUB_STREAMS[parent_stream])
     return sub_stream_names
 
+
+def get_abs_path(path):
+    return os.path.join(os.path.dirname(os.path.realpath(__file__)), path)
+
+
+def get_side_load_schemas(sideload_objects, stream):
+    stream_schema = stream.schema.to_dict()
+    for sideload_object in sideload_objects:
+        if sideload_object in SIDELOAD_OBJECTS[stream.tap_stream_id]:
+            schema_file = "schemas/sideload_schemas/{}.json".format(sideload_object)
+            with open(get_abs_path(schema_file)) as f:
+                schema = json.load(f)
+                stream_schema['properties'][list(schema['properties'].keys())[0]] = list(schema['properties'].values())[0]
+    return stream_schema
+
+
 class DependencyException(Exception):
     pass
+
 
 def validate_dependencies(selected_stream_ids):
     errs = []
@@ -85,13 +114,14 @@ def validate_dependencies(selected_stream_ids):
     if errs:
         raise DependencyException(" ".join(errs))
 
+
 def populate_class_schemas(catalog, selected_stream_names):
     for stream in catalog.streams:
         if stream.tap_stream_id in selected_stream_names:
             STREAMS[stream.tap_stream_id].stream = stream
 
-def do_sync(client, catalog, state, config):
 
+def do_sync(client, catalog, state, config):
     selected_stream_names = get_selected_streams(catalog)
     validate_dependencies(selected_stream_names)
     populate_class_schemas(catalog, selected_stream_names)
@@ -104,18 +134,12 @@ def do_sync(client, catalog, state, config):
             LOGGER.info("%s: Skipping - not selected", stream_name)
             continue
 
-        # if starting_stream:
-        #     if starting_stream == stream_name:
-        #         LOGGER.info("%s: Resuming", stream_name)
-        #         starting_stream = None
-        #     else:
-        #         LOGGER.info("%s: Skipping - already synced", stream_name)
-        #         continue
-        # else:
-        #     LOGGER.info("%s: Starting", stream_name)
-
-
         key_properties = metadata.get(mdata, (), 'table-key-properties')
+        sideload_objects = metadata.get(mdata, (), 'sideload-objects')
+        if sideload_objects:
+            stream_schema = get_side_load_schemas(sideload_objects, stream)
+            stream.schema = Schema.from_dict(stream_schema)
+
         singer.write_schema(stream_name, stream.schema.to_dict(), key_properties)
 
         sub_stream_names = SUB_STREAMS.get(stream_name)
@@ -126,6 +150,10 @@ def do_sync(client, catalog, state, config):
                 sub_stream = STREAMS[sub_stream_name].stream
                 sub_mdata = metadata.to_map(sub_stream.metadata)
                 sub_key_properties = metadata.get(sub_mdata, (), 'table-key-properties')
+                sideload_objects = metadata.get(mdata, (), 'sideload-objects')
+                if sideload_objects:
+                    sub_stream_schema = get_side_load_schemas(sideload_objects, sub_stream)
+                    sub_stream.schema = Schema.from_dict(sub_stream_schema)
                 singer.write_schema(sub_stream.tap_stream_id, sub_stream.schema.to_dict(), sub_key_properties)
 
         # parent stream will sync sub stream
@@ -143,6 +171,7 @@ def do_sync(client, catalog, state, config):
     LOGGER.info("Finished sync")
     zendesk_metrics.log_aggregate_rates()
 
+
 def oauth_auth(args):
     if not set(OAUTH_CONFIG_KEYS).issubset(args.config.keys()):
         LOGGER.debug("OAuth authentication unavailable.")
@@ -153,6 +182,7 @@ def oauth_auth(args):
         "subdomain": args.config['subdomain'],
         "oauth_token": args.config['access_token'],
     }
+
 
 def api_token_auth(args):
     if not set(API_TOKEN_CONFIG_KEYS).issubset(args.config.keys()):
@@ -165,6 +195,7 @@ def api_token_auth(args):
         "email": args.config['email'],
         "token": args.config['api_token']
     }
+
 
 def get_session(config):
     """ Add partner information to requests Session object if specified in the config. """
@@ -180,6 +211,7 @@ def get_session(config):
     session.headers["X-Zendesk-Marketplace-Organization-Id"] = str(config.get("marketplace_organization_id", ""))
     session.headers["X-Zendesk-Marketplace-App-Id"] = str(config.get("marketplace_app_id", ""))
     return session
+
 
 @singer.utils.handle_top_exception(LOGGER)
 def main():

--- a/tap_zendesk/__init__.py
+++ b/tap_zendesk/__init__.py
@@ -39,10 +39,7 @@ def request_metrics_patch(self, method, url, **kwargs):
     with singer_metrics.http_request_timer(None):
         return request(self, method, url, **kwargs)
 
-
 Session.request = request_metrics_patch
-
-
 # end patch
 
 def do_discover(client):

--- a/tap_zendesk/__init__.py
+++ b/tap_zendesk/__init__.py
@@ -84,6 +84,7 @@ def get_abs_path(path):
 
 
 def get_side_load_schemas(sideload_objects, stream):
+    """Returns the updated schema after adding side load objects to schema dict"""
     stream_schema = stream.schema.to_dict()
     for sideload_object in sideload_objects:
         if sideload_object in SIDELOAD_OBJECTS[stream.tap_stream_id]:

--- a/tap_zendesk/schemas/sideload_schemas/comment_count.json
+++ b/tap_zendesk/schemas/sideload_schemas/comment_count.json
@@ -1,0 +1,15 @@
+{
+ "type": [
+            "null",
+              "object"
+            ],
+  "properties": {
+    "comment_count": {
+     "type": [
+            "null",
+              "integer"
+            ]
+    }
+  },
+  "additionalProperties": true
+}

--- a/tap_zendesk/schemas/sideload_schemas/dates.json
+++ b/tap_zendesk/schemas/sideload_schemas/dates.json
@@ -1,0 +1,65 @@
+{
+  "type": [
+    "null", 
+    "object"
+  ], 
+  "properties": {
+    "dates": {
+      "type": [
+        "null", 
+        "object"
+      ], 
+      "properties": {
+        "solved_at": {
+          "type": [
+            "null",
+              "string"
+            ],
+            "format": "date-time"
+        }, 
+        "status_updated_at": {
+          "type": [
+            "null",
+              "string"
+            ],
+            "format": "date-time"
+        }, 
+        "assignee_updated_at": {
+          "type": [
+            "null",
+              "string"
+            ],
+            "format": "date-time"
+        }, 
+        "assigned_at": {
+          "type": [
+            "null",
+              "string"
+            ],
+            "format": "date-time"
+        }, 
+        "requester_updated_at": {
+          "type": [
+            "null",
+              "string"
+            ],
+            "format": "date-time"
+        }, 
+        "latest_comment_added_at": {
+          "type": [
+            "null",
+              "string"
+            ],
+            "format": "date-time"
+        }, 
+        "initially_assigned_at": {
+          "type": [
+            "null",
+              "string"
+            ],
+            "format": "date-time"
+        }
+      }
+    }
+  }
+}

--- a/tap_zendesk/schemas/sideload_schemas/metric_sets.json
+++ b/tap_zendesk/schemas/sideload_schemas/metric_sets.json
@@ -1,0 +1,240 @@
+{
+  "type": [
+            "null",
+              "object"
+            ],
+  "properties": {
+    "metric_set": {
+      "type": [
+            "null",
+              "object"
+            ],
+      "properties": {
+        "url": {
+          "type": [
+            "null",
+              "string"
+            ]
+        },
+        "id": {
+          "type": [
+            "null",
+              "integer"
+            ]
+        },
+        "ticket_id": {
+          "type": [
+            "null",
+              "integer"
+            ]
+        },
+        "created_at": {
+          "type": [
+            "null",
+              "string"
+            ]
+        },
+        "updated_at": {
+          "type": [
+            "null",
+              "string"
+            ]
+        },
+        "group_stations": {
+          "type": [
+            "null",
+              "integer"
+            ]
+        },
+        "assignee_stations": {
+          "type": [
+            "null",
+              "integer"
+            ]
+        },
+        "reopens": {
+          "type": [
+            "null",
+              "integer"
+            ]
+        },
+        "replies": {
+          "type": [
+            "null",
+              "integer"
+            ]
+        },
+        "assignee_updated_at": {
+          "type": [
+            "null",
+              "string"
+            ]
+        },
+        "requester_updated_at": {
+          "type": [
+            "null",
+              "string"
+            ]
+        },
+        "status_updated_at": {
+          "type": [
+            "null",
+              "string"
+            ]
+        },
+        "initially_assigned_at": {
+         "type": [
+            "null",
+              "string"
+            ]
+        },
+        "assigned_at": {
+          "type": [
+            "null",
+              "string"
+            ]
+        },
+        "solved_at": {
+          "type": [
+            "null",
+              "string"
+            ]
+        },
+        "latest_comment_added_at": {
+          "type": [
+            "null",
+              "string"
+            ]
+        },
+        "reply_time_in_minutes": {
+          "type": [
+            "null",
+              "object"
+            ],
+          "properties": {
+            "calendar": {
+              "type": [
+            "null",
+              "string"
+            ]
+            },
+            "business": {
+              "type": [
+            "null",
+              "string"
+            ]
+            }
+          },
+          "additionalProperties": true
+        },
+        "first_resolution_time_in_minutes": {
+          "type": [
+            "null",
+              "object"
+            ],
+          "properties": {
+            "calendar": {
+              "type": [
+            "null",
+              "string"
+            ]
+            },
+            "business": {
+              "type": [
+            "null",
+              "string"
+            ]
+            }
+          },
+          "additionalProperties": true
+        },
+        "full_resolution_time_in_minutes": {
+          "type": [
+            "null",
+              "object"
+            ],
+          "properties": {
+            "calendar": {
+              "type": [
+            "null",
+              "string"
+            ]
+            },
+            "business": {
+             "type": [
+            "null",
+              "string"
+            ]
+            }
+          },
+          "additionalProperties": true
+        },
+        "agent_wait_time_in_minutes": {
+          "type": [
+            "null",
+              "object"
+            ],
+          "properties": {
+            "calendar": {
+             "type": [
+            "null",
+              "string"
+            ]
+            },
+            "business": {
+              "type": [
+            "null",
+              "string"
+            ]
+            }
+          },
+          "additionalProperties": true
+        },
+        "requester_wait_time_in_minutes": {
+          "type": [
+            "null",
+              "object"
+            ],
+          "properties": {
+            "calendar": {
+             "type": [
+            "null",
+              "string"
+            ]
+            },
+            "business": {
+              "type": [
+            "null",
+              "string"
+            ]
+            }
+          },
+          "additionalProperties": true
+        },
+        "on_hold_time_in_minutes": {
+          "type": [
+            "null",
+              "object"
+            ],
+          "properties": {
+            "calendar": {
+              "type": [
+            "null",
+              "integer"
+            ]
+            },
+            "business": {
+              "type": [
+            "null",
+              "integer"
+            ]
+            }
+          },
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/tap_zendesk/schemas/sideload_schemas/slas.json
+++ b/tap_zendesk/schemas/sideload_schemas/slas.json
@@ -1,0 +1,51 @@
+{
+ "type": [
+            "null",
+              "object"
+            ],
+  "properties": {
+    "slas": {
+     "type": [
+            "null",
+              "object"
+            ],
+      "properties": {
+        "policy_metrics": {
+          "type": "array",
+          "items":{
+             "type": [
+            "null",
+              "object"
+            ],
+              "properties": {
+                "breach_at": {
+                  "type": [
+            "null",
+              "string"
+            ]
+                },
+                "stage": {
+                  "type": [
+            "null",
+              "string"
+            ]
+                },
+                "metric": {
+                  "type": [
+            "null",
+              "string"
+            ]
+                },
+                "hours": {
+                 "type": [
+            "null",
+              "string"
+            ]
+                }
+              }
+          }
+        }
+      }
+    }
+  }
+}

--- a/tap_zendesk/streams.py
+++ b/tap_zendesk/streams.py
@@ -29,7 +29,6 @@ CUSTOM_TYPES = {
 DEFAULT_SEARCH_WINDOW_SIZE = (60 * 60 * 24) * 30 # defined in seconds, default to a month (30 days)
 
 def get_sideload_objects(stream):
-    LOGGER.info("inside sideload values === " + str(metadata.to_map(stream.metadata).get((), {}).get('sideload-objects')))
     return metadata.to_map(stream.metadata).get((), {}).get('sideload-objects')
 
 def get_abs_path(path):
@@ -277,7 +276,6 @@ class Tickets(Stream):
             self.update_bookmark(state, utils.strftime(generated_timestamp_dt))
 
             ticket_dict = ticket.to_dict()
-            LOGGER.info("keys ====" + str(ticket_dict.keys()))
             ticket_dict.pop('fields') # NB: Fields is a duplicate of custom_fields, remove before emitting
             should_yield = self._buffer_record((self.stream, ticket_dict))
 

--- a/tap_zendesk/streams.py
+++ b/tap_zendesk/streams.py
@@ -277,7 +277,7 @@ class Tickets(Stream):
             self.update_bookmark(state, utils.strftime(generated_timestamp_dt))
 
             ticket_dict = ticket.to_dict()
-            LOGGER.info("keys ====" + str(ticket_dict.keys))
+            LOGGER.info("keys ====" + str(ticket_dict.keys()))
             ticket_dict.pop('fields') # NB: Fields is a duplicate of custom_fields, remove before emitting
             should_yield = self._buffer_record((self.stream, ticket_dict))
 

--- a/tap_zendesk/streams.py
+++ b/tap_zendesk/streams.py
@@ -28,6 +28,9 @@ CUSTOM_TYPES = {
 
 DEFAULT_SEARCH_WINDOW_SIZE = (60 * 60 * 24) * 30 # defined in seconds, default to a month (30 days)
 
+def get_sideload_objects(stream):
+    return metadata.to_map(stream.metadata).get((), {}).get('sideload-objects')
+
 def get_abs_path(path):
     return os.path.join(os.path.dirname(os.path.realpath(__file__)), path)
 
@@ -250,7 +253,8 @@ class Tickets(Stream):
 
     def sync(self, state):
         bookmark = self.get_bookmark(state)
-        tickets = self.client.tickets.incremental(start_time=bookmark)
+        sideload_objects = get_sideload_objects(self.stream)
+        tickets = self.client.tickets.incremental(start_time=bookmark, include=sideload_objects)
 
         audits_stream = TicketAudits(self.client)
         metrics_stream = TicketMetrics(self.client)

--- a/tap_zendesk/streams.py
+++ b/tap_zendesk/streams.py
@@ -29,6 +29,7 @@ CUSTOM_TYPES = {
 DEFAULT_SEARCH_WINDOW_SIZE = (60 * 60 * 24) * 30 # defined in seconds, default to a month (30 days)
 
 def get_sideload_objects(stream):
+    """Returns the value of sideload-objects from metadata, returns None if no values are present"""
     return metadata.to_map(stream.metadata).get((), {}).get('sideload-objects')
 
 def get_abs_path(path):

--- a/tap_zendesk/streams.py
+++ b/tap_zendesk/streams.py
@@ -29,6 +29,7 @@ CUSTOM_TYPES = {
 DEFAULT_SEARCH_WINDOW_SIZE = (60 * 60 * 24) * 30 # defined in seconds, default to a month (30 days)
 
 def get_sideload_objects(stream):
+    LOGGER.info("inside sideload values === " + str(metadata.to_map(stream.metadata).get((), {}).get('sideload-objects')))
     return metadata.to_map(stream.metadata).get((), {}).get('sideload-objects')
 
 def get_abs_path(path):
@@ -255,7 +256,7 @@ class Tickets(Stream):
         bookmark = self.get_bookmark(state)
         sideload_objects = get_sideload_objects(self.stream)
         tickets = self.client.tickets.incremental(start_time=bookmark, include=sideload_objects)
-
+        LOGGER.info("one record -----> " + str(tickets[0].to_dict()))
         audits_stream = TicketAudits(self.client)
         metrics_stream = TicketMetrics(self.client)
         comments_stream = TicketComments(self.client)

--- a/tap_zendesk/streams.py
+++ b/tap_zendesk/streams.py
@@ -256,7 +256,6 @@ class Tickets(Stream):
         bookmark = self.get_bookmark(state)
         sideload_objects = get_sideload_objects(self.stream)
         tickets = self.client.tickets.incremental(start_time=bookmark, include=sideload_objects)
-        LOGGER.info("one record -----> " + str(tickets[0].to_dict()))
         audits_stream = TicketAudits(self.client)
         metrics_stream = TicketMetrics(self.client)
         comments_stream = TicketComments(self.client)
@@ -278,6 +277,7 @@ class Tickets(Stream):
             self.update_bookmark(state, utils.strftime(generated_timestamp_dt))
 
             ticket_dict = ticket.to_dict()
+            LOGGER.info("keys ====" + str(ticket_dict.keys))
             ticket_dict.pop('fields') # NB: Fields is a duplicate of custom_fields, remove before emitting
             should_yield = self._buffer_record((self.stream, ticket_dict))
 


### PR DESCRIPTION
# Description of change
Adding the functionality to side load ticket objects 
https://developer.zendesk.com/documentation/ticketing/using-the-zendesk-api/side_loading/#special-sideloads

1. Added a new field "sideload-objects" that can be passed in the metadata of the catalog file as a list
2. A variable "SIDELOAD_OBJECTS" added which has a list of all objects that can be side loaded to tickets (more can be added later) 
3. Method added to add the schema for these side loaded objects to stream.schema which will check if these objects are valid side load objects and add the schema if true
4. Change added to fetch tickets call to include sideload objects
# Manual QA steps
 - Tested by loading the side load objects
 - test table can be temporarily found here in public.raw_zendesk_tickets_test_sideload (internal to twilio)
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
