### PR TITLE
adding end_date support

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,7 @@ There are two ways in which the records are returned:
 1. Within the same object as a column
 2. As a separate object 
 
-Here we have provided support for sideloading only the 1st type i.e. the attributes returned in the same object
-as additional columns
+Here we have provided support for sideloading only the 1st type i.e. the attributes returned in the same object as additional columns
 
 Sideload supported for tickets:
 1. comment_count

--- a/README.md
+++ b/README.md
@@ -19,8 +19,10 @@ OAuth is the default authentication method for `tap-zendesk`. To use OAuth, you 
 {
   "access_token": "AVERYLONGOAUTHTOKEN",
   "subdomain": "acme",
-  "start_date": "2000-01-01T00:00:00Z"
+  "start_date": "2000-01-01T00:00:00Z",
 }
+
+
 ```
 
 ### Using API Tokens
@@ -37,4 +39,50 @@ For a simplified, but less granular setup, you can use the API Token authenticat
 }
 ```
 
+An optional end_date field is can be added to the config.json 
+This functionality has been added to ease the backfill procedure for a limited time duration for Zendesk
+
+If passed, data would be loaded for date >= start_date and date < end_date
+
+### Sideloading for tickets
+
+Sideloading is a functionality provided by Zendesk to fetch related records in a single request 
+more detail - https://developer.zendesk.com/documentation/ticketing/using-the-zendesk-api/side_loading/
+
+There are two ways in which the records are returned:
+
+1. Within the same object as a column
+2. As a separate object 
+
+Here we have provided support for sideloading only the 1st type i.e. the attributes returned in the same object
+as additional columns
+
+Sideload supported for tickets:
+1. comment_count
+2. dates
+3. metric_sets
+4. slas
+
+To sideload an object a list can be passed in the metadata for tickets object in the catalog.json file
+
+e.g.
+```json
+"metadata": [
+        {
+          "breadcrumb": [],
+          "metadata": {
+            "table-key-properties": [
+              "id"
+            ],
+            "forced-replication-method": "INCREMENTAL",
+            "valid-replication-keys": [
+              "generated_timestamp"
+            ],
+            sideload-objects: ["comment_count","dates","metric_events","slas"]
+          }
+        }
+```
+
+note: above extract is a part of the complete metadata for tickets 
+### 
 Copyright &copy; 2018 Stitch

--- a/README.md
+++ b/README.md
@@ -77,9 +77,10 @@ e.g.
             "valid-replication-keys": [
               "generated_timestamp"
             ],
-            sideload-objects: ["comment_count","dates","metric_events","slas"]
-          }]
-        }
+            "sideload-objects": ["comment_count","dates","metric_events","slas"]
+          }
+        }]
+}
 ```
 
 note: above extract is a part of the complete metadata for tickets 

--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ For a simplified, but less granular setup, you can use the API Token authenticat
 }
 ```
 
-An optional end_date field is can be added to the config.json 
+An optional `end_date` field can be added to the `config.json`
 This functionality has been added to ease the backfill procedure for a limited time duration for Zendesk
 
-If passed, data would be loaded for date >= start_date and date < end_date
+If passed, data would be loaded for `date >= start_date and date < end_date`
 
 ### Sideloading for tickets
 
@@ -62,11 +62,11 @@ Sideload supported for tickets:
 3. metric_sets
 4. slas
 
-To sideload an object a list can be passed in the metadata for tickets object in the catalog.json file
+To sideload an object a list can be passed in the metadata under `sideload-objects` for tickets object in the catalog.json file
 
 e.g.
 ```json
-"metadata": [
+{"metadata": [
         {
           "breadcrumb": [],
           "metadata": {
@@ -78,7 +78,7 @@ e.g.
               "generated_timestamp"
             ],
             sideload-objects: ["comment_count","dates","metric_events","slas"]
-          }
+          }]
         }
 ```
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ OAuth is the default authentication method for `tap-zendesk`. To use OAuth, you 
 {
   "access_token": "AVERYLONGOAUTHTOKEN",
   "subdomain": "acme",
-  "start_date": "2000-01-01T00:00:00Z",
+  "start_date": "2000-01-01T00:00:00Z"
 }
 
 

--- a/tap_zendesk/__init__.py
+++ b/tap_zendesk/__init__.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import json
 import sys, os
-
+from datetime import datetime
 from zenpy import Zenpy
 import requests
 from requests import Session
@@ -215,7 +215,6 @@ def get_session(config):
 @singer.utils.handle_top_exception(LOGGER)
 def main():
     parsed_args = singer.utils.parse_args(REQUIRED_CONFIG_KEYS)
-
     # OAuth has precedence
     creds = oauth_auth(parsed_args) or api_token_auth(parsed_args)
     session = get_session(parsed_args.config)

--- a/tap_zendesk/streams.py
+++ b/tap_zendesk/streams.py
@@ -35,12 +35,13 @@ def get_sideload_objects(stream):
 
 def check_end_date(record, config, replication_key):
     if 'end_date' in config:
-        record_key_date =process_record(record)[replication_key]
+        record_key_date = process_record(record)[replication_key]
         end_date = round(datetime.datetime.strptime(config['end_date'], "%Y-%m-%dT%H:%M:%SZ").timestamp())
         if not isinstance(record_key_date, int):
             record_key_date = round(datetime.datetime.strptime(record_key_date, "%Y-%m-%dT%H:%M:%SZ").timestamp())
         return record_key_date > end_date
-    else: return False;
+    else:
+        return False
 
 def get_abs_path(path):
     return os.path.join(os.path.dirname(os.path.realpath(__file__)), path)
@@ -156,7 +157,7 @@ class Organizations(Stream):
         organizations = self.client.organizations.incremental(start_time=bookmark)
         for organization in organizations:
             if check_end_date(organization, self.config, self.replication_key):
-                break;
+                break
             self.update_bookmark(state, organization.updated_at)
             yield (self.stream, organization)
 

--- a/tap_zendesk/streams.py
+++ b/tap_zendesk/streams.py
@@ -292,7 +292,7 @@ class Tickets(Stream):
             generated_timestamp_dt = datetime.datetime.utcfromtimestamp(ticket.generated_timestamp).replace(tzinfo=pytz.UTC)
 
             if check_end_date(ticket, self.config, self.replication_key):
-                break;
+                break
 
             self.update_bookmark(state, utils.strftime(generated_timestamp_dt))
 
@@ -563,7 +563,7 @@ class TicketMetricEvents(Stream):
         ticket_metric_events = self.client.ticket_metric_events(start_time=bookmark)
         for ticket_metric_event in ticket_metric_events:
             if check_end_date(ticket_metric_event, self.config, self.replication_key):
-                break;
+                break
             if utils.strptime_with_tz(ticket_metric_event.time) >= bookmark:
                 # NB: We don't trust that the records come back ordered by
                 # updated_at (we've observed out-of-order records),

--- a/tap_zendesk/streams.py
+++ b/tap_zendesk/streams.py
@@ -35,9 +35,9 @@ def get_sideload_objects(stream):
 
 def check_end_date(record, end_date, replication_key):
     record_key_date =process_record(record)[replication_key]
-    end_date = round(datetime.datetime.strptime(end_date, "%Y-%m-%dT%I:%M:%SZ").timestamp())
+    end_date = round(datetime.datetime.strptime(end_date, "%Y-%m-%dT%H:%M:%SZ").timestamp())
     if not isinstance(record_key_date, int):
-        record_key_date = round(datetime.datetime.strptime(record_key_date, "%Y-%m-%dT%I:%M:%SZ").timestamp())
+        record_key_date = round(datetime.datetime.strptime(record_key_date, "%Y-%m-%dT%H:%M:%SZ").timestamp())
     return record_key_date > end_date
 
 def get_abs_path(path):
@@ -184,7 +184,7 @@ class Users(Stream):
         start = bookmark - datetime.timedelta(seconds=1)
         end = start + datetime.timedelta(seconds=search_window_size)
         if 'end_date' in self.config:
-            sync_end = datetime.datetime.strptime(self.config['end_date'], "%Y-%m-%dT%I:%M:%SZ").replace(tzinfo=pytz.UTC)
+            sync_end = datetime.datetime.strptime(self.config['end_date'], "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=pytz.UTC)
         else:
             sync_end = singer.utils.now() - datetime.timedelta(minutes=1)
         parsed_sync_end = singer.strftime(sync_end, "%Y-%m-%dT%H:%M:%SZ")
@@ -397,7 +397,7 @@ class SatisfactionRatings(Stream):
         start = bookmark - datetime.timedelta(seconds=1)
         end = start + datetime.timedelta(seconds=search_window_size)
         if 'end_date' in self.config:
-            sync_end = datetime.datetime.strptime(self.config['end_date'], "%Y-%m-%dT%I:%M:%SZ").replace(tzinfo=pytz.UTC)
+            sync_end = datetime.datetime.strptime(self.config['end_date'], "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=pytz.UTC)
         else:
             sync_end = singer.utils.now() - datetime.timedelta(minutes=1)
         epoch_sync_end = int(sync_end.strftime('%s'))


### PR DESCRIPTION
# Description of change
Added support for end date
--> Zendesk api does not support end date and sends all data >= start_date in pages of 1000 records each
--> Added a check for end_date for the data
--> if end date is reached, the loop over the pages is exited 


# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
