### PR TITLE
Fixes assumed PRIMARY KEYs for SQL-based targets like Redshift

### DIFF
--- a/tap_zendesk/streams.py
+++ b/tap_zendesk/streams.py
@@ -574,6 +574,7 @@ class TicketMetricEvents(Stream):
 class AgentsActivity(Stream):
     name = "agents_activity"
     replication_method = "FULL_TABLE"
+    key_properties = ["agent_id"]
 
     def sync(self, state): # pylint: disable=unused-argument
 


### PR DESCRIPTION
# Description of change
(write a short description or paste a link to JIRA)

Adds `agent_id` as key property of AgentsActivity so SQL targets can use it as PRIMARY KEY.

Logs of exception that prompted me to fix this:

```
target-redshift | time=2021-08-31 13:57:03 name=target_redshift level=INFO message=Running query: CREATE TABLE IF NOT EXISTS tap_zendesk."AGENTS_ACTIVITY" ("ACCEPTED_THIRD_PARTY_CONFERENCES" numeric, "ACCEPTED_TRANSFERS" numeric, "AGENT_ID" numeric, "AGENT_STATE" character varying(10000), "AVAILABLE_TIME" numeric, "AVATAR_URL" character varying(10000), "AVERAGE_HOLD_TIME" numeric, "AVERAGE_TALK_TIME" numeric, "AVERAGE_WRAP_UP_TIME" numeric, "AWAY_TIME" numeric, "CALL_STATUS" character varying(10000), "CALLS_ACCEPTED" numeric, "CALLS_DENIED" numeric, "CALLS_MISSED" numeric, "CALLS_PUT_ON_HOLD" numeric, "FORWARDING_NUMBER" character varying(10000), "NAME" character varying(10000), "ONLINE_TIME" numeric, "STARTED_THIRD_PARTY_CONFERENCES" numeric, "STARTED_TRANSFERS" numeric, "TOTAL_CALL_DURATION" numeric, "TOTAL_HOLD_TIME" numeric, "TOTAL_TALK_TIME" numeric, "TOTAL_WRAP_UP_TIME" numeric, "TRANSFERS_ONLY_TIME" numeric, "VIA" character varying(10000), PRIMARY KEY ("ID"))
target-redshift | time=2021-08-31 13:57:03 name=target_redshift level=INFO message=None
target-redshift | Traceback (most recent call last):
target-redshift |   File "/project/.meltano/loaders/target-redshift/venv/bin/target-redshift", line 8, in <module>
target-redshift |     sys.exit(main())
target-redshift |   File "/project/.meltano/loaders/target-redshift/venv/lib/python3.6/site-packages/target_redshift/__init__.py", line 447, in main
target-redshift |     persist_lines(config, singer_messages, table_cache)
target-redshift |   File "/project/.meltano/loaders/target-redshift/venv/lib/python3.6/site-packages/target_redshift/__init__.py", line 242, in persist_lines
target-redshift |     stream_to_sync[stream].sync_table()
target-redshift |   File "/project/.meltano/loaders/target-redshift/venv/lib/python3.6/site-packages/target_redshift/db_sync.py", line 739, in sync_table
target-redshift |     self.create_table_and_grant_privilege()
target-redshift |   File "/project/.meltano/loaders/target-redshift/venv/lib/python3.6/site-packages/target_redshift/db_sync.py", line 719, in create_table_and_grant_privilege
target-redshift |     self.create_table(is_stage=is_stage)
target-redshift |   File "/project/.meltano/loaders/target-redshift/venv/lib/python3.6/site-packages/target_redshift/db_sync.py", line 716, in create_table
target-redshift |     self.query(self.create_table_query(is_stage=is_stage))
target-redshift |   File "/project/.meltano/loaders/target-redshift/venv/lib/python3.6/site-packages/target_redshift/db_sync.py", line 338, in query
target-redshift |     params
target-redshift |   File "/project/.meltano/loaders/target-redshift/venv/lib/python3.6/site-packages/psycopg2/extras.py", line 143, in execute
target-redshift |     return super(DictCursor, self).execute(query, vars)
target-redshift | psycopg2.errors.UndefinedColumn: column "id" named in key does not exist
```

# Manual QA steps
 - NA
 
# Risks
 - None?
 
# Rollback steps
 - revert this branch
