### PR TITLE
Adds `lookup` custom type to type lookup.

### DIFF
--- a/tap_zendesk/streams.py
+++ b/tap_zendesk/streams.py
@@ -25,6 +25,7 @@ CUSTOM_TYPES = {
     'integer': 'integer',
     'decimal': 'number',
     'checkbox': 'boolean',
+    'lookup': 'integer',
 }
 
 DEFAULT_SEARCH_WINDOW_SIZE = (60 * 60 * 24) * 30 # defined in seconds, default to a month (30 days)


### PR DESCRIPTION
# Description of change
This PR adds the lookup custom type to the CUSTOM_TYPES lookup. Lookups are references to other zendesk resources so their values are integers.

Without it the discovery step will fail when it finds the lookup field. I'm using Meltano, just an FYI.

Resources:
https://support.zendesk.com/hc/en-us/articles/4552827736218-Announcing-lookup-relationship-fields-for-Support
https://support.zendesk.com/hc/en-us/articles/4591924111770#topic_wny_w3k_5tb
https://developer.zendesk.com/documentation/ticketing/using-the-zendesk-api/retrieving-lookup-relationship-fields-with-the-api/

# Manual QA steps
 - Ran against zendesk environment that uses lookups.
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
