### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
       install_requires=[
           'pipelinewise-singer-python==1.2.0',
           'zenpy==2.0.25',
+          'requests==2.20.0"
       ],
       extras_require={
           'dev': [


### PR DESCRIPTION
pinning version of requests to avoid urllib3 ssl issue 

ImportError: urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with OpenSSL 1.0.2k-fips 26 Jan 2017. See: https://github.com/urllib3/urllib3/issues/2168

# Description of change
Pinning the version of requests library 

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
