### PR TITLE
DAXPINTAKE-2635 Omit GET requests for deleted tickets

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ This functionality has been added to ease the backfill procedure for a limited t
 
 If passed, data would be loaded for `date >= start_date and date < end_date`
 
+A second, optional, configurable field `skip_deleted` can also be passed in the config. This defaults to `True`, and means that if a ticket's status field is `deleted`, the audits, metrics and comments will not be requested for that ticket ID. 
+
+Note that the `status = deleted` flag is only valid for the `/incremental/tickets` endpoint, not `/tickets`.
+
 ### Sideloading for tickets
 
 Sideloading is a functionality provided by Zendesk to fetch related records in a single request 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
       name='twilio-tap-zendesk',
-      version='1.0.14',
+      version='1.0.15',
       description='Singer.io tap for extracting data from the Zendesk API',
       author='Twilio',
       url='https://github.com/twilio-labs/twilio-tap-zendesk',


### PR DESCRIPTION
# Description of change
[DAXPINTAKE-2635](https://twilio-engineering.atlassian.net/browse/DAXPINTAKE-2635) Omit GET requests for deleted tickets
If configurable `skip_deleted` flag is `true` (default), then sub-streams ticket audits, metrics and comments will not be requested for tickets with `status = deleted`

# Manual QA steps
 - tested locally for date range known to contain tickets with `status = deleted`
 - tested in production but no tickets with `status = deleted` encountered
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
