### PR TITLE
DAXPINTAKE-2656 Fix for breaking change in zenpy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
       name='twilio-tap-zendesk',
-      version='1.0.16',
+      version='1.0.17',
       description='Singer.io tap for extracting data from the Zendesk API',
       author='Twilio',
       url='https://github.com/twilio-labs/twilio-tap-zendesk',

--- a/tap_zendesk/streams.py
+++ b/tap_zendesk/streams.py
@@ -400,7 +400,7 @@ class SatisfactionRatings(Stream):
             # minutes, due to this, the tap will adjust the time range
             # dynamically to ensure bookmarks are able to be written in
             # cases of high volume.
-            if satisfaction_ratings.count > 50000:
+            if len(satisfaction_ratings) > 50000:
                 search_window_size = search_window_size // 2
                 end = start + datetime.timedelta(seconds=search_window_size)
                 LOGGER.info("satisfaction_ratings - Detected Search API response size for this window is too large (> 50k). Cutting search window in half to %s seconds.", search_window_size)


### PR DESCRIPTION
# Description of change
[DAXPINTAKE-2656](https://twilio-engineering.atlassian.net/browse/DAXPINTAKE-2656) Fix for breaking change in zenpy. Error occurring in `satisfaction_ratings` stream:
`AttributeError: 'GenericCursorResultsGenerator' object has no attribute 'count'`

# Manual QA steps
 - Changes tested locally
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
