### PR TITLE
Bump requests to 2.32.3 to add Python 3.12 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
       install_requires=[
           'pipelinewise-singer-python==1.2.0',
           'zenpy==2.0.49',
-          'requests==2.31.0',
+          'requests==2.32.3',
       ],
       extras_require={
           'dev': [
@@ -27,6 +27,7 @@ setup(
           [console_scripts]
           tap-zendesk=tap_zendesk:main
       ''',
+      python_requires=">=3.8",
       packages=['tap_zendesk'],
       include_package_data=True,
 )

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
       install_requires=[
           'pipelinewise-singer-python==1.2.0',
           'zenpy==2.0.49',
-          'requests==2.20.0'
+          'requests==2.31.0',
       ],
       extras_require={
           'dev': [


### PR DESCRIPTION
# Description of change

Bumps `requests` to 2.32 to add support for Python 3.12. This also means dropping support for Python 3.7 (EOL 2023-06-27). See [the release history](https://requests.readthedocs.io/en/latest/community/updates/#id4) for more details.

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
